### PR TITLE
Feature/ option to add conjuction word

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,16 @@ import arraySemanticJoin from 'array-semantic-join';
     const userNames = ['John', 'Jane', 'Patrick'];
 
     ...
-
     <span>
         {arraySemanticJoin(userNames)} // output: "John, Jane and Patrick"
+    </span>
+
+    <span>
+        {arraySemanticJoin(userNames, { word: 'a' } )} // output: "John, Jane a Patrick"
+    </span>
+
+    <span>
+        {arraySemanticJoin(userNames, { word: 'und' } )} // output: "John, Jane und Patrick"
     </span>
 ...
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'array-semantic-join' {
+  const arraySemanticJoin: (arr: string[], options?: { word: string }) => string
+
+  export default arraySemanticJoin
+}
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 declare module 'array-semantic-join' {
-  const arraySemanticJoin: (arr: string[], options?: { word: string }) => string
+  const arraySemanticJoin: (
+    arr: string[],
+    options?: { word: string },
+  ) => string;
 
-  export default arraySemanticJoin
+  export default arraySemanticJoin;
 }
-

--- a/index.js
+++ b/index.js
@@ -1,10 +1,22 @@
 'use-strict';
 
-module.exports = function(inputArray){
+var defaultOptions = {
+    word: 'and'
+}
+
+module.exports = function (inputArray, options) {
+
     if (!Array.isArray(inputArray)) {
         console.warn(`Wrong argument in function arraySemanticJoin. Expect Array instead of ${typeof inputArray}`);
         return '';
     }
+
+    if (options && typeof options.word !== 'string') {
+        console.warn(`Wrong options argument used. Expected Object with property 'word' as string instead of ${typeof options.word}`);
+        return '';
+    }
+
+    options = options || defaultOptions
 
     if (inputArray.length === 0) {
         return '';
@@ -12,5 +24,5 @@ module.exports = function(inputArray){
         return inputArray[0];
     }
 
-    return inputArray.slice(0, -1).join(', ') + ' and\u00A0' + inputArray.slice(-1);
+    return inputArray.slice(0, -1).join(', ') + ' ' + options.word + '\u00A0' + inputArray.slice(-1);
 }

--- a/index.test.js
+++ b/index.test.js
@@ -42,3 +42,50 @@ describe("Test function: arraySemanticJoin", () => {
         expect(arraySemanticJoin(MORE_ITEMS_ARRAY)).toBe('John, Jane, Paul and\u00A0Patrick');
     });
 });
+
+describe("Test function: arraySemanticJoin with own cunjuction string", () => {
+    test("Empty array", () => {
+        expect(arraySemanticJoin(EMPTY_ARRAY, {word: 'a'})).toBe('');
+    });
+
+    test("Empty array", () => {
+        expect(arraySemanticJoin(EMPTY_ARRAY, {word: 'und'})).toBe('');
+    });
+
+    test("One item array", () => {
+        expect(arraySemanticJoin(ONE_ITEM_ARRAY, {word: 'a'})).toBe('John');
+    });
+
+    test("One item array", () => {
+        expect(arraySemanticJoin(ONE_ITEM_ARRAY, {word: 'und'})).toBe('John');
+    });
+
+    test("Two items array", () => {
+        expect(arraySemanticJoin(TWO_ITEMS_ARRAY, {word: 'a'})).toBe('John a Jane');
+    });
+
+    test("Two items array", () => {
+        expect(arraySemanticJoin(TWO_ITEMS_ARRAY, {word: 'und'})).toBe('John und Jane');
+    });
+
+    test("More items array", () => {
+        expect(arraySemanticJoin(MORE_ITEMS_ARRAY, {word: 'a'})).toBe('John, Jane, Paul a Patrick');
+    });
+
+    test("More items array", () => {
+        expect(arraySemanticJoin(MORE_ITEMS_ARRAY, {word: 'und'})).toBe('John, Jane, Paul und Patrick');
+    });
+
+
+    test("Wrong options parameter", () => {
+        expect(arraySemanticJoin(MORE_ITEMS_ARRAY, {word: ['a']})).toBe('');
+    });
+
+    test("Wrong options parameter", () => {
+        expect(arraySemanticJoin(MORE_ITEMS_ARRAY, {word: 1})).toBe('');
+    });
+
+    test("Wrong options parameter", () => {
+        expect(arraySemanticJoin(MORE_ITEMS_ARRAY, {conjunction: 'und'})).toBe('');
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "array-semantic-join",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "array-semantic-join",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Helper function whose input is an array and output is a semantic string with joined items of the input array.",
     "homepage": "https://github.com/kontentino/array-semantic-join",
     "main": "index.js",


### PR DESCRIPTION
This PR is adding functionality for choosing conjunction word between joined strings as response for #13.

It Includes updated:
- tests
- readme
- added Typescript declarations

Now there is possibility to pass `options` as second unrequired argument with property `'word'`

*example*
```js
arraySemanticJoin(['Filip', 'Patrik', 'Lukas'], { word: 'a' }) // 'Filip, Patrik a Lukas'

arraySemanticJoin(['Filip', 'Patrik', 'Lukas']) // 'Filip, Patrik and Lukas'
```

_Note:
For default parameters here I've used old technique instead of [Default Parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) because it's not supported in IE and this package is not transpiled.

